### PR TITLE
Add comprehensive dataset status values to API documentation

### DIFF
--- a/api-reference/retrieve-dataset-status.mdx
+++ b/api-reference/retrieve-dataset-status.mdx
@@ -45,6 +45,20 @@ curl -H "Authorization: Bearer <jwt>" https://app.visual-layer.com/api/v1/datase
 }
 ```
 
+## Dataset Status Values
+
+The `status` field in the response can have the following values:
+
+- `NEW` - Dataset has been created but not yet started processing
+- `PRE_PROCESSING` - Dataset is being prepared for processing
+- `INITIALIZING` - Dataset processing is being initialized
+- `UPLOADING` - Data is being uploaded to the system
+- `SAVING` - Dataset data is being saved
+- `INDEXING` - Dataset is being indexed for search and retrieval
+- `READY` - Dataset is fully processed and ready for use
+- `FATAL_ERROR` - An error occurred during processing that prevents completion
+- `ENRICHING` - Dataset is being enriched with additional metadata or processing
+
 <Tip>
 Use this endpoint to track dataset readiness before continuing with enrichment, filtering, or export operations.
 </Tip>


### PR DESCRIPTION
## Summary
- Added complete list of dataset status values to the retrieve dataset status API documentation
- Documents all possible states: NEW, PRE_PROCESSING, INITIALIZING, UPLOADING, SAVING, INDEXING, READY, FATAL_ERROR, ENRICHING
- Provides clear descriptions for each status to help users understand the dataset processing lifecycle

## Test plan
- [ ] Review documentation formatting and clarity
- [ ] Verify all status values are accurately described
- [ ] Confirm the documentation integrates well with existing content

🤖 Generated with [Claude Code](https://claude.ai/code)