### PR TITLE
Add OBJECT_STORE_URL configuration flag to S3 documentation

### DIFF
--- a/docs/on-prem/s3-configuration.mdx
+++ b/docs/on-prem/s3-configuration.mdx
@@ -18,7 +18,8 @@ The following configuration should be added to the config.json file inside the .
   "SOURCE_USE_FULLPATH": true,
   "USE_S5CMD_WHEN_AVAILABLE": true,
   "SKIP_IMAGE_THUMBNAIL_GENERATION": true,
-  "EXPORT_ENTITIES_RESULT_BUCKET": "mybucket"
+  "EXPORT_ENTITIES_RESULT_BUCKET": "mybucket",
+  "OBJECT_STORE_URL": "http://minio:9000"
 }
 ```
 
@@ -63,6 +64,13 @@ The following configuration should be added to the config.json file inside the .
 - **Format**: Should contain just the bucket name without the `s3://` prefix (e.g., `"mybucket"` instead of `"s3://mybucket/"`).
 - **Use case**: When exporting entities or results, files will be stored in this bucket instead of the default location.
 - **Optional**: Yes – if not specified, exports will use the default export location.
+
+### OBJECT_STORE_URL: "http://minio:9000"
+- **Purpose**: Configures a custom S3-compatible object storage endpoint URL for the system.
+- **Use case**: Allows using alternative object storage services (like MinIO or on-premise S3-compatible storage) instead of AWS S3. Enables on-premise or custom object storage deployments.
+- **Behavior**: When set, it overrides the default AWS S3 endpoint for all storage operations including downloads and preprocessing artifact storage.
+- **Technical details**: When URL starts with `http://`, SSL verification is disabled for local deployments. Used for both data downloads and preprocessing operations.
+- **Optional**: Yes – if not specified, the system will use the default AWS S3 endpoint.
 
 ## 🔐 AWS Credentials Setup
 


### PR DESCRIPTION
## Summary
- Add OBJECT_STORE_URL configuration flag documentation to S3 configuration
- Include comprehensive documentation for custom S3-compatible object storage endpoints
- Document usage for MinIO and on-premise deployments

## Test plan
- [ ] Review documentation for clarity and accuracy
- [ ] Verify JSON configuration example is valid
- [ ] Confirm flag description matches actual system behavior

🤖 Generated with [Claude Code](https://claude.ai/code)