### PR TITLE
Add 20-character limit documentation for enum fields

### DIFF
--- a/docs/Creating-Datasets/custom-metadata.mdx
+++ b/docs/Creating-Datasets/custom-metadata.mdx
@@ -26,7 +26,7 @@ All API requests in the Cloud environment require [authentication using a valid 
 - `string`
 - `float`
 - `datetime` (UTC format)
-- `enum` (single or multi-select)
+- `enum` (single or multi-select) - each enum option is limited to 20 characters
 - `link` (URL)
 
 <Note>


### PR DESCRIPTION
## Summary
- Added documentation about the 20-character limit for enum field options in custom metadata
- Updated the supported value types section to clearly specify this constraint

## Test plan
- [x] Verified the change is accurate and properly formatted
- [x] Confirmed the documentation follows existing patterns

🤖 Generated with [Claude Code](https://claude.ai/code)