### PR TITLE
Fix API documentation parameter and improve secret handling guidance

### DIFF
--- a/api-reference/authentication.mdx
+++ b/api-reference/authentication.mdx
@@ -40,7 +40,7 @@ Cookies: SESSION=<session from authenticated user browser session>
 {
   "api_key": "<api_key>",
   "api_secret": "<api_secret>",
-  "message": "API key created. Write down the secret – it's only shown once!"
+  "message": "API key created. Write down the secret – it's only shown once! If you need to access your secret again, contact Visual Layer support at support@visual-layer.com."
 }
 ```
 
@@ -82,7 +82,7 @@ def generate_jwt(api_key: str, api_secret: str):
     
     # Convert datetime objects to Unix timestamps (seconds since epoch)
     now = datetime.now(tz=timezone.utc)
-    expiration = now + timedelta(minutes=10) # Time can be modified as needed
+    expiration = now + timedelta(minutes=10) # You can change this to a larger number if needed
     
     payload = {
         'sub': api_key,
@@ -99,7 +99,7 @@ print("VL_Token:" + api_token)
 ```
 
 <Tip>
-JWT tokens expire quickly by design. For best security and performance, regenerate tokens every 10 minutes.
+JWT tokens expire quickly by design. For best security and performance, regenerate tokens periodically based on your security requirements.
 </Tip>
 
 ---

--- a/api-reference/create-a-dataset-from-a-public-s3-bucket.mdx
+++ b/api-reference/create-a-dataset-from-a-public-s3-bucket.mdx
@@ -29,7 +29,7 @@ Headers: Authorization: Bearer <jwt>
 ### Required Form Parameters
 
 - `dataset_name`: *(string)* – The name of the dataset to create  
-- `bucket_name`: *(string)* – The name of the public S3 bucket containing your data  
+- `bucket_path`: *(string)* – The path to the public S3 bucket containing your data  
 
 ---
 
@@ -38,7 +38,7 @@ Headers: Authorization: Bearer <jwt>
 ```bash
 curl -X POST -H "Authorization: Bearer <jwt>" \
      -F dataset_name=api_test \
-     -F bucket_name=public_test_bucket \
+     -F bucket_path=public_test_bucket \
      https://app.visual-layer.com/api/v1/dataset
 ```
 


### PR DESCRIPTION
## Summary
Updated API documentation to fix parameter naming and improve guidance around secret handling and JWT token expiration.

## Changes Made
- **Fixed parameter name**: Changed `bucket_name` to `bucket_path` in S3 dataset creation API documentation
- **Enhanced secret guidance**: Added support contact information (support@visual-layer.com) for users who need to access their secret after initial display
- **Clarified JWT flexibility**: Updated code comments and documentation to specify that expiration minutes can be customized to larger values
- **Removed restrictive limitation**: Modified tip to remove specific 10-minute requirement and make it more flexible based on security needs

## Test plan
- [x] Verify parameter names match actual API implementation
- [x] Confirm support contact information is accurate
- [x] Review JWT token generation code examples for clarity

🤖 Generated with [Claude Code](https://claude.ai/code)