### PR TITLE
Add legal cards to landing page

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -93,7 +93,7 @@ hidden: true
 </div>
 
 {/* ── Resources strip ── */}
-<div className="vl-landing-section vl-landing-section-last">
+<div className="vl-landing-section">
   <h2 className="vl-landing-section-title">Resources</h2>
   <CardGroup cols={3}>
     <Card title="Release Notes" icon="megaphone" href="/docs/release-notes/release-notes">
@@ -105,6 +105,15 @@ hidden: true
     <Card title="Model Catalog" icon="boxes" href="/docs/Dataset-Enrichment/model-catalog">
       Browse available enrichment models and their capabilities.
     </Card>
+  </CardGroup>
+</div>
+
+{/* ── Legal ── */}
+<div className="vl-landing-legal">
+  
+  <CardGroup cols={2}>
+    <Card title="Terms of Service" icon="scale" href="/docs/terms-of-service" />
+    <Card title="Privacy Policy" icon="shield" href="/docs/privacy-policy" />
   </CardGroup>
 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1007,4 +1007,34 @@ img.img-sm[data-rmiz-modal-img] {
   max-height: 90% !important;
 }
 
+/* Legal cards — compact variant */
+.vl-landing-legal {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 2rem 4rem;
+}
+
+.vl-landing-legal hr {
+  border: none;
+  border-top: 1px solid rgba(37, 22, 73, 0.12);
+  margin: 0 0 1.5rem;
+}
+
+.dark .vl-landing-legal hr {
+  border-top-color: rgba(255, 255, 255, 0.1);
+}
+
+.vl-landing-legal [data-component-part="card"] {
+  padding: 0.5rem 0.75rem !important;
+  font-size: 0.8rem !important;
+}
+
+.vl-landing-legal [data-component-part="card-title"] {
+  font-size: 0.85rem !important;
+}
+
+.vl-landing-legal [data-component-part="card-content"] {
+  display: none !important;
+}
+
 /* End of CSS */


### PR DESCRIPTION
## Summary
- Adds compact Terms of Service and Privacy Policy cards at the bottom of the landing page
- Includes CSS for smaller card styling

## Test plan
- [ ] Verify cards render on landing page
- [ ] Verify cards link to correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)