### PR TITLE
Add Dataset Interface Reference scaffold + fix inline marker icon sizing

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -105,7 +105,17 @@
                             "docs/explore-and-search/vl-chat",
                             "docs/explore-and-search/visual-search",
                             "docs/explore-and-search/recipes",
-                            "docs/explore-and-search/using-search-filter"
+                            "docs/explore-and-search/using-search-filter",
+                            {
+                                "group": "Dataset Interface Reference",
+                                "pages": [
+                                    "docs/explore-and-search/dataset-interface-reference",
+                                    "docs/explore-and-search/dataset-interface-explore-tab",
+                                    "docs/explore-and-search/dataset-interface-data-tab",
+                                    "docs/explore-and-search/dataset-interface-views-tab",
+                                    "docs/explore-and-search/dataset-interface-enrich-tab"
+                                ]
+                            }
                         ]
                     },
                     {

--- a/docs/explore-and-search/dataset-interface-data-tab.mdx
+++ b/docs/explore-and-search/dataset-interface-data-tab.mdx
@@ -1,0 +1,60 @@
+---
+title: "Data Tab"
+description: "Reference for the Data tab inside a Visual Layer dataset — setup checklist, media preview, and activity log."
+sidebarTitle: "Data tab"
+---
+
+The **Data** tab is the dataset's setup and status surface. It shows how the dataset was configured, the media that was ingested into it, and the history of operations that have run on it.
+
+<Note>
+This page is a scaffold. Each section below will be filled in with complete coverage as the reference is built out.
+</Note>
+
+## Layout Overview
+
+The Data tab is organized into three areas.
+
+<div className="integrations-table">
+
+| Region | Purpose |
+|--------|---------|
+| **Creation Checklist** | Shows the five setup stages the dataset passed through: data source, annotations, index type, upload, and indexing |
+| **Media Preview** | A grid preview of the media that was uploaded into the dataset |
+| **Activity Log** | A chronological log of operations (saving, indexing, ready, and so on) with timestamps |
+
+</div>
+
+## Creation Checklist
+
+The creation checklist displays the five stages that completed when the dataset was created: **Select Data Source**, **Add Annotations**, **Select Index Type**, **Upload Data**, and **Visual Layer Indexing**.
+
+_Scaffold: Document what each stage represents, the state it shows after completion, and how the checklist relates to the dataset status._
+
+## Media Preview
+
+The media preview shows a paginated grid of the images uploaded to the dataset along with file names and label availability indicators.
+
+_Scaffold: Document the grid, file-name display, labels-available indicator, and any hover or click affordances._
+
+## Activity Log
+
+The activity log lists completed and in-progress operations for the dataset with timestamps and status indicators.
+
+_Scaffold: Document each log entry type, status indicator, and any filter or sort controls on the log panel._
+
+## Related Resources
+
+<CardGroup cols={2}>
+  <Card title="Dataset Interface Reference" icon="layout-dashboard" href="/docs/explore-and-search/dataset-interface-reference">
+    Overview of the full dataset workspace and the four tabs
+  </Card>
+  <Card title="Explore Tab" icon="search" href="/docs/explore-and-search/dataset-interface-explore-tab">
+    The workspace for viewing and analyzing dataset content
+  </Card>
+  <Card title="Views Tab" icon="blend" href="/docs/explore-and-search/dataset-interface-views-tab">
+    Saved combinations of filters and search queries
+  </Card>
+  <Card title="Enrich Tab" icon="sparkles" href="/docs/explore-and-search/dataset-interface-enrich-tab">
+    Model selection and enrichment progress tracking
+  </Card>
+</CardGroup>

--- a/docs/explore-and-search/dataset-interface-enrich-tab.mdx
+++ b/docs/explore-and-search/dataset-interface-enrich-tab.mdx
@@ -1,0 +1,60 @@
+---
+title: "Enrich Tab"
+description: "Reference for the Enrich tab inside a Visual Layer dataset — model selection and enrichment progress tracking."
+sidebarTitle: "Enrich tab"
+---
+
+The **Enrich** tab is where AI-driven enrichment of the dataset is configured and monitored. It exposes the model picker, the preview of model output, and the progress view for running enrichment jobs.
+
+<Note>
+This page is a scaffold. Each section below will be filled in with complete coverage as the reference is built out.
+</Note>
+
+## Layout Overview
+
+The Enrich tab is organized into three areas.
+
+<div className="integrations-table">
+
+| Region | Purpose |
+|--------|---------|
+| **Model Picker** | Select one or more models to run against the dataset |
+| **Preview Panel** | Show a sample of model output on a small set of images before committing to a full run |
+| **Progress View** | Track the status of running enrichment jobs and review past jobs |
+
+</div>
+
+## Model Picker
+
+The model picker lists the models available for enrichment and allows selecting one or more to apply to the dataset.
+
+_Scaffold: Document the model list, model metadata, selection behavior, and any version or compatibility indicators._
+
+## Preview Panel
+
+The preview panel runs the selected model(s) on a small sample of images and displays the output so the results can be inspected before committing to a full run.
+
+_Scaffold: Document the sample set, the output display, and any iterate or discard affordances._
+
+## Progress View
+
+The progress view shows the status of in-flight enrichment jobs and the history of completed jobs, including any notifications generated along the way.
+
+_Scaffold: Document the per-job status indicators, timestamps, the notifications surface, and the relationship between this view and the Task Manager._
+
+## Related Resources
+
+<CardGroup cols={2}>
+  <Card title="Dataset Interface Reference" icon="layout-dashboard" href="/docs/explore-and-search/dataset-interface-reference">
+    Overview of the full dataset workspace and the four tabs
+  </Card>
+  <Card title="Enrich Overview" icon="sparkles" href="/docs/advanced-dataset-management/enrich-overview">
+    How enrichment works and how to configure it end-to-end
+  </Card>
+  <Card title="Task Manager" icon="list-checks" href="/docs/advanced-features/task-manager">
+    Monitor every running task, including enrichment jobs
+  </Card>
+  <Card title="Explore Tab" icon="search" href="/docs/explore-and-search/dataset-interface-explore-tab">
+    Where enriched metadata becomes filterable and searchable
+  </Card>
+</CardGroup>

--- a/docs/explore-and-search/dataset-interface-explore-tab.mdx
+++ b/docs/explore-and-search/dataset-interface-explore-tab.mdx
@@ -1,0 +1,84 @@
+---
+title: "Explore Tab"
+description: "Reference for every panel, control, and action inside the Explore tab of a Visual Layer dataset."
+sidebarTitle: "Explore tab"
+---
+
+The **Explore** tab is the primary workspace inside a dataset. All viewing, search, filtering, cluster navigation, quality analysis, and selection happen here.
+
+<Note>
+This page is a scaffold. Each section below will be filled in with complete control-by-control coverage as the reference is built out.
+</Note>
+
+<Frame>
+  <img src="/images/overview-cluster-view.png" alt="Explore tab of the dataset workspace" />
+</Frame>
+
+## Layout Overview
+
+The Explore tab is organized into five screen regions that stay in place as you navigate. Each region is covered in its own section below.
+
+<div className="integrations-table">
+
+| Region | Purpose |
+|--------|---------|
+| **Top Tab Bar** | Switches between **Explore**, **Data**, **Views**, and **Enrich** |
+| **Filter Panel** | Apply and combine filters, search tools, and metadata criteria |
+| **Action Bar** | Run operations on the current result set: export, share, selection management |
+| **Content Grid** | The main display area showing clusters, images, or objects |
+| **Details Sidebar** | View metadata, insights, statistics, and access enrichment features |
+
+</div>
+
+## Top Tab Bar
+
+The top tab bar is the entry point to the four dataset tabs. In the Explore tab, it also hosts workspace-level controls such as the dataset title, dataset status indicator, and VL Chat launcher.
+
+_Scaffold: Document each element in the top bar, including hover states, badge indicators, and the **Ask VL** button._
+
+## View Mode Switcher
+
+The Content Grid supports multiple view modes. **Clusters** is the default; a flat grid view is available as an alternative for reviewing every image linearly without grouping.
+
+_Scaffold: Document the Clusters view (including the granularity knob), the Images flat view, and the Objects view, plus the controls that switch between them._
+
+## Filter Panel
+
+The Filter Panel is where every filter, search, and criterion applies to the current result set. It adapts to the current view mode and exposes semantic search, visual similarity, metadata filters, and quality filters.
+
+_Scaffold: Document each filter group, operator, threshold control, and clear/reset affordance._
+
+## Action Bar
+
+The Action Bar hosts operations that act on the current result set or selection: export, share, bulk selection, bulk tagging, and save view.
+
+_Scaffold: Document each action button, including its selection-state behavior and the dialogs it opens._
+
+## Content Grid
+
+The Content Grid is the main display area. It renders clusters, images, or objects depending on the current view mode, and it is the source of all in-place actions like hover to preview, select, or Find Similar.
+
+_Scaffold: Document the cluster thumbnail affordances, the hover + crop Find Similar entry point, the region-of-interest selection, the image card, the object card, and every context menu._
+
+## Details Sidebar
+
+The Details Sidebar shows metadata, insights, and statistics for the current view or selection, and provides access to enrichment features such as **Ask VL**.
+
+_Scaffold: Document each tab in the sidebar, each metric shown, and each call-to-action it exposes._
+
+## Related Resources
+
+<CardGroup cols={2}>
+  <Card title="Dataset Interface Reference" icon="layout-dashboard" href="/docs/explore-and-search/dataset-interface-reference">
+    Overview of the full dataset workspace and the four tabs
+  </Card>
+  <Card title="Data Tab" icon="database" href="/docs/explore-and-search/dataset-interface-data-tab">
+    The dataset's setup and status surface
+  </Card>
+  <Card title="Views Tab" icon="blend" href="/docs/explore-and-search/dataset-interface-views-tab">
+    Saved combinations of filters and search queries
+  </Card>
+  <Card title="Enrich Tab" icon="sparkles" href="/docs/explore-and-search/dataset-interface-enrich-tab">
+    Model selection and enrichment progress tracking
+  </Card>
+</CardGroup>

--- a/docs/explore-and-search/dataset-interface-reference.mdx
+++ b/docs/explore-and-search/dataset-interface-reference.mdx
@@ -1,0 +1,49 @@
+---
+title: "Dataset Interface Reference"
+description: "A complete reference to every tab, panel, control, and action in the Visual Layer dataset workspace."
+sidebarTitle: "Dataset Interface Ref"
+---
+
+The **Dataset Interface Reference** catalogs every element of the dataset workspace in Visual Layer. Use it to look up what a specific control does, where it lives, and which actions it supports.
+
+<Note>
+This reference is under active construction. The parent overview below is stable; the linked tab-specific pages are scaffolds that will be filled in as each surface is documented in detail.
+</Note>
+
+Click any dataset in the **Dataset Inventory** to open the dataset workspace. The workspace organizes all dataset work into four top-level tabs.
+
+<Frame>
+  <img src="/images/overview-cluster-view.png" alt="Dataset workspace showing the Explore tab" />
+</Frame>
+
+## Interface Layout
+
+The dataset workspace is divided into four tabs. Each tab hosts a distinct set of controls, panels, and actions, and each has its own reference page.
+
+<div className="integrations-table">
+
+| Area | Tab | Description |
+|------|-----|-------------|
+| <img src="/images/1light.png" className="img-marker" alt="1" /> | [**Explore**](/docs/explore-and-search/dataset-interface-explore-tab) | The primary workspace for viewing and analyzing dataset content — clusters, search, filters, quality signals, and selection |
+| <img src="/images/2light.png" className="img-marker" alt="2" /> | [**Data**](/docs/explore-and-search/dataset-interface-data-tab) | The dataset's setup and status surface — creation checklist, media preview, and activity log |
+| <img src="/images/3light.png" className="img-marker" alt="3" /> | [**Views**](/docs/explore-and-search/dataset-interface-views-tab) | Saved combinations of filters and search queries, plus monitoring and sharing controls |
+| <img src="/images/4light.png" className="img-marker" alt="4" /> | [**Enrich**](/docs/explore-and-search/dataset-interface-enrich-tab) | Model selection and progress tracking for AI-driven enrichment of the dataset |
+
+</div>
+
+## Related Resources
+
+<CardGroup cols={2}>
+  <Card title="Exploring Datasets" icon="search" href="/docs/quick-start/dataset-exploration-ux">
+    High-level orientation to the dataset workspace and the exploration workflow
+  </Card>
+  <Card title="How Search & Filter Work" icon="scan-text" href="/docs/explore-and-search/explore-theory">
+    Concepts behind semantic search, visual similarity, and quality signals
+  </Card>
+  <Card title="How to Search & Filter" icon="sliders-horizontal" href="/docs/explore-and-search/using-search-filter">
+    Step-by-step guide to running searches and filters
+  </Card>
+  <Card title="About the Dataset Inventory" icon="layout-dashboard" href="/docs/quick-start/dataset-inventory-ux">
+    The home page you land on before opening a dataset
+  </Card>
+</CardGroup>

--- a/docs/explore-and-search/dataset-interface-views-tab.mdx
+++ b/docs/explore-and-search/dataset-interface-views-tab.mdx
@@ -1,0 +1,53 @@
+---
+title: "Views Tab"
+description: "Reference for the Views tab inside a Visual Layer dataset — saved filter combinations, monitoring, and sharing."
+sidebarTitle: "Views tab"
+---
+
+The **Views** tab lists every saved view for the dataset. A saved view captures a specific combination of filters, search queries, and thresholds so it can be reloaded later or shared with the team.
+
+<Note>
+This page is a scaffold. Each section below will be filled in with complete coverage as the reference is built out.
+</Note>
+
+## Layout Overview
+
+The Views tab is organized into two areas.
+
+<div className="integrations-table">
+
+| Region | Purpose |
+|--------|---------|
+| **Views Table** | The list of saved views with their metadata, monitoring state, and actions |
+| **Expanded Row** | When a row is expanded, shows the trend chart, image preview grid, and share panel for the selected view |
+
+</div>
+
+## Views Table
+
+The views table displays one row per saved view with columns for name, creator, creation date, monitoring state, and row actions.
+
+_Scaffold: Document each column, the monitoring toggle, the three-dot menu actions (edit, duplicate, delete), and the row-expand affordance._
+
+## Expanded Row
+
+Expanding a view reveals the trend chart, a preview grid of current results, and the sharing panel for granting access to other users.
+
+_Scaffold: Document the trend chart axes and tooltips, the preview grid, and the share panel controls._
+
+## Related Resources
+
+<CardGroup cols={2}>
+  <Card title="Dataset Interface Reference" icon="layout-dashboard" href="/docs/explore-and-search/dataset-interface-reference">
+    Overview of the full dataset workspace and the four tabs
+  </Card>
+  <Card title="Explore Tab" icon="search" href="/docs/explore-and-search/dataset-interface-explore-tab">
+    The workspace for viewing and analyzing dataset content
+  </Card>
+  <Card title="Data Tab" icon="database" href="/docs/explore-and-search/dataset-interface-data-tab">
+    The dataset's setup and status surface
+  </Card>
+  <Card title="Saved Views" icon="blend" href="/docs/collab-and-downstream/saved-views">
+    Creating, sharing, and monitoring saved views
+  </Card>
+</CardGroup>

--- a/docs/explore-and-search/vl-chat.mdx
+++ b/docs/explore-and-search/vl-chat.mdx
@@ -22,7 +22,7 @@ sidebarTitle: "VL Chat"
 
 ## How to Use VL Chat
 
-To access **VL Chat**, open any dataset in Visual Layer and click <img src="/images/start-vl-chat.png" alt="Ask VL button" style={{ height: '28px', display: 'inline-block', verticalAlign: 'middle' }} /> in the top navigation bar. The chat interface appears as a panel on the right side of your screen, allowing you to explore while viewing your dataset.
+To access **VL Chat**, open any dataset in Visual Layer and click <img src="/images/start-vl-chat.png" alt="Ask VL button" className="img-marker" /> in the top navigation bar. The chat interface appears as a panel on the right side of your screen, allowing you to explore while viewing your dataset.
 
 Each dataset maintains its own conversation thread, which persists across sessions. To start a fresh conversation, click **New Thread** in the chat panel.
 

--- a/docs/quick-start/dataset-inventory-dataset-cards.mdx
+++ b/docs/quick-start/dataset-inventory-dataset-cards.mdx
@@ -29,7 +29,7 @@ Each dataset card displays essential information:
 | **Object Count** | Number of annotated objects (if metadata or enrichment includes object detection) |
 | **Video Count** | Number of videos in the dataset (if applicable) |
 | **Video Frame Count** | Number of frames extracted from videos (if applicable) |
-| **Info Icon** <img src="/images/info-i-icon.png" width="20" /> | Hover to view additional metadata such as associated folder paths, upload source, or custom fields |
+| **Info Icon** <img src="/images/info-i-icon.png" className="img-marker-sm" alt="Info icon" /> | Hover to view additional metadata such as associated folder paths, upload source, or custom fields |
 | **Three-Dot Menu** | Access dataset actions including **Copy URL**, **Duplicate**, and **Delete** |
 
 </div>

--- a/docs/quick-start/dataset-inventory-ux.mdx
+++ b/docs/quick-start/dataset-inventory-ux.mdx
@@ -18,9 +18,9 @@ The Dataset Inventory consists of three primary areas that work together to help
 
 | Area | Component | Description |
 |------|-----------|-------------|
-| <img src="/images/1light.png" width="28" /> | [**Main Panel**](/docs/quick-start/dataset-inventory-main-panel) | Search for datasets by name and apply filters |
-| <img src="/images/2light.png" width="28" /> | [**Dataset Cards Grid**](/docs/quick-start/dataset-inventory-dataset-cards) | Visual display of all your datasets with key information and quick actions |
-| <img src="/images/3light.png" width="28" /> | [**Create Dataset Button**](/docs/quick-start/tutorial-create-dataset) | Start creating a new dataset |
+| <img src="/images/1light.png" className="img-marker" alt="1" /> | [**Main Panel**](/docs/quick-start/dataset-inventory-main-panel) | Search for datasets by name and apply filters |
+| <img src="/images/2light.png" className="img-marker" alt="2" /> | [**Dataset Cards Grid**](/docs/quick-start/dataset-inventory-dataset-cards) | Visual display of all your datasets with key information and quick actions |
+| <img src="/images/3light.png" className="img-marker" alt="3" /> | [**Create Dataset Button**](/docs/quick-start/tutorial-create-dataset) | Start creating a new dataset |
 
 </div>
 

--- a/docs/quick-start/navigating-visual-layer.mdx
+++ b/docs/quick-start/navigating-visual-layer.mdx
@@ -14,11 +14,11 @@ The **Navigation Panel** is persistent across both areas of Visual Layer, provid
 
 | Icon/Option | Name | Description |
 |-------------|------|-------------|
-| <img src="/images/dataset-inventory-icon.png" width="28" /> | **My Datasets** | Return to the Dataset Inventory home page (current view) |
-| <img src="/images/task-manager-icon.png" width="28" /> | **Task Manager** | Monitor and manage all active tasks, jobs, and processing workflows |
+| <img src="/images/dataset-inventory-icon.png" className="img-marker" alt="My Datasets icon" /> | **My Datasets** | Return to the Dataset Inventory home page (current view) |
+| <img src="/images/task-manager-icon.png" className="img-marker" alt="Task Manager icon" /> | **Task Manager** | Monitor and manage all active tasks, jobs, and processing workflows |
 | <Icon icon="book-open" size={22} /> | **Help Resources** | Access user guides, API references, and tutorials |
 | **Bug Report** | **Feedback** | Report issues or provide feedback to the Visual Layer team |
-| <img src="/images/avatar-icon.png" width="28" /> | **Personal Info** | Click your avatar to view image usage limits (trial accounts default to 10,000 images), subscription status, and active plan details. Also access the light/dark mode toggle and log out. |
+| <img src="/images/avatar-icon.png" className="img-marker" alt="Personal Info avatar icon" /> | **Personal Info** | Click your avatar to view image usage limits (trial accounts default to 10,000 images), subscription status, and active plan details. Also access the light/dark mode toggle and log out. |
 
 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1019,6 +1019,18 @@ img.img-marker {
   vertical-align: middle;
 }
 
+/* Smaller inline marker variant (e.g., info icons alongside labels) */
+img.img-marker-sm {
+  width: 20px !important;
+  height: 20px !important;
+  max-width: 20px !important;
+  max-height: 20px !important;
+  min-width: 0 !important;
+  display: inline-block !important;
+  margin: 0 !important;
+  vertical-align: middle;
+}
+
 /* Legal cards — compact variant */
 .vl-landing-legal {
   max-width: 960px;


### PR DESCRIPTION
## Summary

- **Dataset Interface Reference scaffold.** New nested reference group under Explore & Search, mirroring the existing Dataset Inventory hierarchy: one parent overview page plus one child page per top-level tab (Explore, Data, Views, Enrich). The parent lists all four tabs in an Interface Layout table with numbered markers linking into each child page. Each child page is a scaffold with full section structure and one-sentence placeholder descriptions under an explicit "under construction" `<Note>`. This becomes the home for the in-Explore details that were deferred from `dataset-exploration-ux.mdx` (clusters-vs-flat, hover + crop Find Similar, region-of-interest, and so on).
- **Inline marker icon fix.** Mintlify's default img styles override both `width="..."` attributes and inline `style={}` props on `<img>` tags inside tables, which was rendering every inline marker icon at its full natural size across `navigating-visual-layer`, `dataset-inventory-ux`, `dataset-inventory-dataset-cards`, and `vl-chat`. Replaced those with the `img-marker` class (added yesterday) so the existing `!important` rule wins. Added an `img-marker-sm` 20 px variant for smaller inline labels and applied it to the info-icon in `dataset-inventory-dataset-cards`. Added alt text where it was missing.

## Known follow-ups

- **`dataset-exploration-ux.mdx` Navigation Tabs table is missing Enrich.** The quick-start page lists Explore / Data / Views but the product has four tabs. Flagged here but not fixed in this PR; can update in a follow-up pass once the reference is fleshed out enough to be the canonical source.

## Test plan

- [ ] Run `mintlify dev` and verify the site builds with no console errors
- [ ] Open the Explore & Search group and confirm the new **Dataset Interface Reference** nested group appears at the bottom with all five pages (parent + Explore / Data / Views / Enrich)
- [ ] Visit the parent reference page and verify the four numbered markers in the Interface Layout table render at the correct small size (28 px)
- [ ] Click each of the four tab links in the parent's Interface Layout table and confirm they open the correct child page
- [ ] Visit `navigating-visual-layer`, `dataset-inventory-ux`, `dataset-inventory-dataset-cards`, and `vl-chat` and confirm every inline marker icon renders at the intended small size (28 px for `img-marker`, 20 px for `img-marker-sm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)